### PR TITLE
 Use of nil reference when connection cannot be opened

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -387,12 +387,14 @@ func (c *boltConn) Close() error {
 		return nil
 	}
 
-	err := c.conn.Close()
-	c.closed = true
-	if err != nil {
-		c.connErr = errors.Wrap(err, "An error occurred closing the connection")
-		return driver.ErrBadConn
+	if c.conn != nil {
+		err := c.conn.Close()
+		if err != nil {
+			c.connErr = errors.Wrap(err, "An error occurred closing the connection")
+			return driver.ErrBadConn
+		}
 	}
+	c.closed = true
 
 	return nil
 }


### PR DESCRIPTION
Merge from https://github.com/johnnadratowski/golang-neo4j-bolt-driver/pull/63